### PR TITLE
Use HTTPS with Paperclip images

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,7 +11,7 @@ class Event < ActiveRecord::Base
     storage: :s3,
     url: ":s3_domain_url",
     path: ":class/:attachment/:id_partition/:style/:filename",
-    s3_protocol: 'http',
+    s3_protocol: 'https',
     s3_region: "us-west-2",
     s3_credentials: {
       bucket: "hollowearth-event-images",

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -15,7 +15,7 @@ class Program < ActiveRecord::Base
     storage: :s3,
     url: ":s3_domain_url",
     path: ":class/:attachment/:id_partition/:style/:filename",
-    s3_protocol: 'http',
+    s3_protocol: 'https',
     s3_region: "us-west-2",
     s3_credentials: {
       bucket: "hollowearth-program-images",


### PR DESCRIPTION
Change Paperclip to retrieve images using HTTPS instead of HTTP